### PR TITLE
View shared errors page

### DIFF
--- a/app/controllers/contracts_controller.rb
+++ b/app/controllers/contracts_controller.rb
@@ -1,0 +1,34 @@
+class ContractsController < ApplicationController
+  before_action :authenticate_user!
+
+  def new
+    @contract = Contract.new
+  end
+
+  def create
+    @contract = Contract.new(contract_params)
+    @contract.user = current_user
+    if @contract.save
+      flash[:success] = "Contract was created successfully"
+      redirect_to contract_path(@contract)
+    else
+      render 'new'
+    end  
+  end
+
+  def update
+        if @contract.update(contract_params)
+      flash[:success] = "Contract was successfully updated"
+      redirect_to contract_path(@contract)
+    else
+      render 'edit'
+    end
+  end
+
+  private
+
+  def contract_params
+    params.require(:contract).permit(:start_date, :end_date, :confirmed)
+  end
+
+end

--- a/app/models/contract.rb
+++ b/app/models/contract.rb
@@ -2,7 +2,7 @@ class Contract < ApplicationRecord
   belongs_to :user
   belongs_to :service
   
-  validates :start_date, :end_date, :confirmed, precenses: :true
+  validates :start_date, :end_date, :confirmed, presence: true
   
   # TODO: Add method with "callback" for checking end date is not before start date
 end

--- a/app/views/contracts/_form.html.erb
+++ b/app/views/contracts/_form.html.erb
@@ -1,0 +1,6 @@
+<%= render 'shared/errors', obj: @contract %>
+
+<font color="black">
+  This is the rendered content: Some Simple form here after new or editl.
+  The topic above here is from the new.html.erb or edit.html.erb depending on where you came from.
+</font>

--- a/app/views/contracts/edit.html.erb
+++ b/app/views/contracts/edit.html.erb
@@ -1,0 +1,3 @@
+<h1>Contracts edit page </h1>
+
+<%= render "form" %>

--- a/app/views/contracts/new.html.erb
+++ b/app/views/contracts/new.html.erb
@@ -1,0 +1,3 @@
+<h1>Contracts page created page</h1>
+
+<%= render "form" %>

--- a/app/views/shared/_errors.html.erb
+++ b/app/views/shared/_errors.html.erb
@@ -1,0 +1,21 @@
+<% if obj.errors.any? %>
+  <div class="row">
+    <div class="col-xs-8 col-xs-offset-2">
+      <div class="panel panel-danger">
+        <div class="panel-heading">
+          <h2 class="panel-title">
+            <%= pluralize(obj.errors.count, "error") %>
+            prohibited this item from being saved:
+          </h2>
+          <div class="panel-body">
+            <ul>
+              <% obj.errors.full_messages.each do |msg| %>
+                <li><%= msg %></li>
+              <% end %>
+            </ul>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+<% end %>


### PR DESCRIPTION
This is an attempt to create a user-friendly error page.
the page is placed in the /shared folder and can be embedded by other files from the view.
You can call it with <%= render 'shared/errors', obj: @variable_name %> on the _form.html.erb page