### PR TITLE
Sticky-bottom on footer, no longer fixed-bottom (covering our content)

### DIFF
--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -1,4 +1,4 @@
-<div class="footer fixed-bottom">
+<div class="footer sticky-bottom">
   <div class="footer-links">
     <a href="#"><i class="fab fa-github"></i></a>
     <a href="#"><i class="fab fa-instagram"></i></a>


### PR DESCRIPTION
So that footer always shows at the end of our content/bottom of the page (not covering our content on full pages)